### PR TITLE
Fix options passed in the constructor.

### DIFF
--- a/src/angular-websocket.js
+++ b/src/angular-websocket.js
@@ -330,8 +330,8 @@
       });
     }
 
-    return function(url, protocols) {
-      return new $WebSocket(url, protocols);
+    return function(url, protocols, options) {
+      return new $WebSocket(url, protocols, options);
     };
   }
 


### PR DESCRIPTION
It was not possible to pass options to the $websocket constructor.
This fix should also resolve the issue : https://github.com/gdi2290/angular-websocket/issues/18, if you do : ws = $websocket('ws://127.0.0.1:8888', null, {reconnectIfNotNormalClose: true});